### PR TITLE
Fix quoting in powershell

### DIFF
--- a/sai.ps1
+++ b/sai.ps1
@@ -23,7 +23,7 @@ try {
         $result = Install-WindowsFeature $toInstall -IncludeAllSubFeature -IncludeManagementTools
         Write-Host "Installed features: $($toInstall -join ', ')"
         if ($result.RestartNeeded -eq 'Yes') {
-            Write-Warning 'Un redémarrage est nécessaire pour terminer l\'installation.'
+            Write-Warning "Un redémarrage est nécessaire pour terminer l'installation."
         }
     } else {
         Write-Host "Required features already installed."


### PR DESCRIPTION
## Summary
- escape the apostrophe correctly in the PowerShell script

## Testing
- `pwsh --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685545380cd88323ac5bf0e6ddecd2fc